### PR TITLE
fix: add spelling stats helper and quality color tests

### DIFF
--- a/src/__tests__/getQualityColor.test.js
+++ b/src/__tests__/getQualityColor.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getQualityColor } from '../utils/getQualityColor.js';
+
+test('returns green for good quality', () => {
+  assert.equal(getQualityColor('good'), 'text-green-600 bg-green-100');
+});
+
+test('returns yellow for fair quality', () => {
+  assert.equal(getQualityColor('fair'), 'text-yellow-600 bg-yellow-100');
+});
+
+test('returns red for poor quality', () => {
+  assert.equal(getQualityColor('poor'), 'text-red-600 bg-red-100');
+});
+
+test('returns gray for unknown quality', () => {
+  assert.equal(getQualityColor('unknown'), 'text-gray-600 bg-gray-100');
+});

--- a/src/pages/dictation.jsx
+++ b/src/pages/dictation.jsx
@@ -5,6 +5,9 @@ import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Prog
 // @ts-ignore;
 import { Play, Pause, RotateCcw, Volume2, CheckCircle, ArrowRight, ArrowLeft, SkipBack, SkipForward, AlertCircle, Check, X, CheckSquare, XSquare } from 'lucide-react';
 
+// @ts-ignore;
+import { getQualityColor } from '../utils/getQualityColor';
+
 export default function DictationPage(props) {
   const {
     $w,
@@ -154,11 +157,7 @@ export default function DictationPage(props) {
 
   // 重播当前单词
   const replayWord = () => {
-    setIsPlaying(true);
-    setPlaybackQuality('good'); // 重试时默认设为良好质量
-    setTimeout(() => {
-      setIsPlaying(false);
-    }, 2000);
+    playWord();
   };
 
   // 记录拼写结果
@@ -258,24 +257,24 @@ export default function DictationPage(props) {
   };
 
   // 获取播放质量颜色
-  const getQualityColor = () => {
-    switch (playbackQuality) {
-      case 'good':
-        return 'text-green-600 bg-green-100';
-      case 'fair':
-        return 'text-yellow-600 bg-yellow-100';
-      case 'poor':
-        return 'text-red-600 bg-red-100';
-      default:
-        return 'text-gray-600 bg-gray-100';
-    }
-  };
+  const getQualityColorClass = () => getQualityColor(playbackQuality);
 
   // 获取当前单词的拼写状态
-  const getCurrentSpellingStatus极狐 = () => {
+  const getCurrentSpellingStatus = () => {
     const currentWordId = mockWords[currentWordIndex].id;
     return spellingResults[currentWordId];
   };
 
   // 计算拼写统计
-  const calculateSpellingStats = () =>
+  const calculateSpellingStats = () => {
+    const total = mockWords.length;
+    const correct = Object.values(spellingResults).filter(result => result === 'correct').length;
+    const incorrect = Object.values(spellingResults).filter(result => result === 'incorrect').length;
+    const accuracy = total ? (correct / total * 100).toFixed(1) : '0';
+    return {
+      total,
+      correct,
+      incorrect,
+      accuracy
+    };
+  };

--- a/src/pages/parentHome.jsx
+++ b/src/pages/parentHome.jsx
@@ -131,7 +131,7 @@ export default function ParentHomepage(props) {
   return <div style={style} className="min-h-screen bg-gray-50">
       {/* 顶部导航 */}
       <header className="bg-white shadow-sm border-b">
-        <div className="max-w-极狐6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
               <BookOpen className="h-8 w-8 text-blue-600 mr-3" />
@@ -143,7 +143,7 @@ export default function ParentHomepage(props) {
                     {unreadCount}
                   </Badge>
                   <div className="absolute -top-1 -right-1 flex h-3 w-3">
-                    <span className极狐="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
                     <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
                   </div>
                 </div>}
@@ -195,7 +195,7 @@ export default function ParentHomepage(props) {
               </Badge>}
             
             <Button variant="outline" size="sm" onClick={() => setShowAllAssignments(!showAllAssignments)} className="flex items-center">
-              {showAllAssignments ? <EyeOff className="w-4 h-4 mr-2" /> : <极狐Eye className="w-4 h-4 mr-2" />}
+              {showAllAssignments ? <EyeOff className="w-4 h-4 mr-2" /> : <Eye className="w-4 h-4 mr-2" />}
               {showAllAssignments ? '只看新作业' : '显示所有作业'}
             </Button>
           </div>
@@ -235,7 +235,7 @@ export default function ParentHomepage(props) {
                     
                     {/* 教材单元信息 */}
                     <div className="mb-4">
-                      <div className="极狐flex flex-wrap gap-2">
+                      <div className="flex flex-wrap gap-2">
                         <span className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm">
                           📚 {assignment.textbook}
                         </span>

--- a/src/utils/getQualityColor.js
+++ b/src/utils/getQualityColor.js
@@ -1,0 +1,12 @@
+export function getQualityColor(quality) {
+  switch (quality) {
+    case 'good':
+      return 'text-green-600 bg-green-100';
+    case 'fair':
+      return 'text-yellow-600 bg-yellow-100';
+    case 'poor':
+      return 'text-red-600 bg-red-100';
+    default:
+      return 'text-gray-600 bg-gray-100';
+  }
+}


### PR DESCRIPTION
## Summary
- remove stray characters from parent home layout
- implement spelling statistics helper and ensure replay triggers playWord
- add reusable quality color helper with unit tests

## Testing
- `node --test`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bddd0ac0bc832381a7ee4962d876a0