### PR TITLE
Handle case-insensitive quality colors

### DIFF
--- a/src/__tests__/getQualityColor.test.js
+++ b/src/__tests__/getQualityColor.test.js
@@ -17,3 +17,11 @@ test('returns red for poor quality', () => {
 test('returns gray for unknown quality', () => {
   assert.equal(getQualityColor('unknown'), 'text-gray-600 bg-gray-100');
 });
+
+test('handles mixed case input', () => {
+  assert.equal(getQualityColor('Good'), 'text-green-600 bg-green-100');
+});
+
+test('returns gray when quality is undefined', () => {
+  assert.equal(getQualityColor(undefined), 'text-gray-600 bg-gray-100');
+});

--- a/src/utils/getQualityColor.js
+++ b/src/utils/getQualityColor.js
@@ -1,5 +1,5 @@
 export function getQualityColor(quality) {
-  switch (quality) {
+  switch (quality?.toLowerCase()) {
     case 'good':
       return 'text-green-600 bg-green-100';
     case 'fair':


### PR DESCRIPTION
## Summary
- normalize quality input before color lookup
- test additional edge cases for `getQualityColor`

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68bdedd00f748323ad6e42b00207a3f2